### PR TITLE
GPIO API interface added

### DIFF
--- a/dwm1001.py
+++ b/dwm1001.py
@@ -345,11 +345,11 @@ class UartDwm1001:
         """! Gets the node mode of the DWM1001.
         @return str: The shell node mode string.
 
-        Example tag in active mode:     "mode: tn (act,twr,np,le)"
-        Example tag in passive mode:    "mode: tn (pasv,twr,lp,le)"
-        Example tag with UWB radio off: "mode: tn (off,twr,np,le)"
-        Example anchor:                 "mode: an (act,-,-)"
-        Example anchor in initiating:   "mode: ani (act,-,-)"
+        - Example tag in active mode:     "mode: tn (act,twr,np,le)"
+        - Example tag in passive mode:    "mode: tn (pasv,twr,lp,le)"
+        - Example tag with UWB radio off: "mode: tn (off,twr,np,le)"
+        - Example anchor:                 "mode: an (act,-,-)"
+        - Example anchor in initiating:   "mode: ani (act,-,-)"
         """
         node_mode_str = self.get_command_output(ShellCommand.GET_MODE.value)
         return node_mode_str

--- a/dwm1001.py
+++ b/dwm1001.py
@@ -44,7 +44,6 @@ class ShellCommand(Enum):
     GET_MODE = "nmg"  # Get node mode: tag, anchor
     GPIO_CLEAR = "gc"  # Set GPIO pin LOW
     GPIO_SET = "gs"  # Set GPIO pin HIGH
-    # GPIO_TOGGLE = "gt"  # Toggle GPIO pin -- Doesn't always work in shell?
     GPIO_GET = "gg"  # Get GPIO pin value
 
 
@@ -106,8 +105,8 @@ class TagPosition:
 
         @exception ParsingError: If the APG line cannot be parsed.
 
-        Example apg position line: x:0 y:0 z:0 qf:0
-        Example apg position line: x:10 y:78888 z:-334 qf:57
+        - Example apg position line: x:0 y:0 z:0 qf:0
+        - Example apg position line: x:10 y:78888 z:-334 qf:57
         """
         # Example line: x:0 y:0 z:0 qf:0
         # Example line: x:10 y:78888 z:-334 qf:57
@@ -138,8 +137,8 @@ class AccelerometerData:
     ---
 
     Measurements come from a ST LIS2DH12TR accelerometer:
-    Documentation: https://www.st.com/resource/en/datasheet/lis2dh12.pdf
-    The LIS2DH12TR can be accessed via TWI/I2C on address 0x33.
+    - Documentation: https://www.st.com/resource/en/datasheet/lis2dh12.pdf
+    - The LIS2DH12TR can be accessed via TWI/I2C on address 0x33.
 
     - These values are on a 2g full scale range (by default).
     - To get the acceleration in gravities, divide by 2^6.
@@ -163,10 +162,10 @@ class UartDwm1001:
     @exception pexpect.exceptions.TIMEOUT: If a timeout occurs while waiting for a response from the DWM1001.
 
     Example usage:
-      dwm1001 = UartDwm1001(serial_handle)
-      dwm1001.connect()
-      tag_position = dwm1001.get_position()
-      dwm1001.disconnect()
+      - dwm1001 = UartDwm1001(serial_handle)
+      - dwm1001.connect()
+      - tag_position = dwm1001.get_position()
+      - dwm1001.disconnect()
     """
 
     __RESET_DELAY_PERIOD = 0.1

--- a/dwm1001.py
+++ b/dwm1001.py
@@ -408,9 +408,9 @@ class UartDwm1001:
 
         Valid pin numbers are: [2, 8, 9, 10, 12, 13, 14, 15, 23, 27]
         """
-        if not self.is_valid_gpio_pin(pin):
-            raise ReservedGPIOPinError(f"GPIO pin {pin} is reserved by the DWM1001.")
         pin_state_str = self.get_command_output(f"{ShellCommand.GPIO_GET.value} {pin}")
+        if "reserved" in pin_state_str:
+            raise ReservedGPIOPinError(f"GPIO pin {pin} is reserved by the DWM1001.")
         return self.parse_gpio_pin_state_str(pin_state_str)
 
     def parse_gpio_pin_state_str(self, pin_state_str: str) -> bool:
@@ -430,16 +430,16 @@ class UartDwm1001:
     def set_gpio_pin_high(self, pin: int) -> None:
         """! Sets a GPIO pin on the DWM1001 to HIGH.
         @param pin (int): The GPIO pin number (0-31)."""
-        if not self.is_valid_gpio_pin(pin):
+        result_str = self.get_command_output(f"{ShellCommand.GPIO_SET.value} {pin}")
+        if "reserved" in result_str:
             raise ReservedGPIOPinError(f"GPIO pin {pin} is reserved by the DWM1001.")
-        self.get_command_output(f"{ShellCommand.GPIO_SET.value} {pin}")
 
     def set_gpio_pin_low(self, pin: int) -> None:
         """! Sets a GPIO pin on the DWM1001 to LOW.
         @param pin (int): The GPIO pin number (0-31)."""
-        if not self.is_valid_gpio_pin(pin):
+        result_str = self.get_command_output(f"{ShellCommand.GPIO_CLEAR.value} {pin}")
+        if "reserved" in result_str:
             raise ReservedGPIOPinError(f"GPIO pin {pin} is reserved by the DWM1001.")
-        self.get_command_output(f"{ShellCommand.GPIO_CLEAR.value} {pin}")
 
     def set_led_on(self) -> None:
         """! Sets the User LED (D12) on the DWM1001 to ON (high).

--- a/examples/print_tag_accelerations.py
+++ b/examples/print_tag_accelerations.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# Standard library imports
+from pathlib import Path
+import sys
+from typing import NoReturn
+from time import sleep
+import logging
+
+# Third party imports
+from serial import Serial
+
+# Allows us to find dwm1001 library without installing it
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import dwm1001
+
+SERIAL_PORT_PATH = "/dev/ttyACM0"
+
+
+def main() -> NoReturn:
+    logging.basicConfig(level=logging.INFO)  # Set to DEBUG for more info
+    # logging.basicConfig(level=logging.DEBUG)  # Set to DEBUG for more info
+
+    serial_handle = Serial(SERIAL_PORT_PATH, baudrate=115200, timeout=5)
+
+    node = dwm1001.UartDwm1001(serial_handle)
+    node.connect()
+
+    print("Connected, printing acceleration, press Ctrl+C to stop")
+
+    try:
+        while True:
+            print(node.get_accelerometer_data())
+            sleep(0.25)
+    except KeyboardInterrupt:
+        print("Caught keyboard interrupt - stopping")
+
+    node.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/set_node_led_on_off.py
+++ b/examples/set_node_led_on_off.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+# Standard library imports
+from pathlib import Path
+import sys
+from typing import NoReturn
+from time import sleep
+import logging
+
+# Third party imports
+from serial import Serial
+
+# Allows us to find dwm1001 library without installing it
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import dwm1001
+
+SERIAL_PORT_PATH = "/dev/ttyACM0"
+
+
+def main() -> NoReturn:
+    logging.basicConfig(level=logging.INFO)  # Set to DEBUG for more info
+    # logging.basicConfig(level=logging.DEBUG)  # Set to DEBUG for more info
+
+    serial_handle = Serial(SERIAL_PORT_PATH, baudrate=115200, timeout=5)
+
+    node = dwm1001.UartDwm1001(serial_handle)
+    node.connect()
+
+    print("Connected, toggling D12, press Ctrl+C to stop")
+
+    try:
+        while True:
+            node.set_led_on()
+            sleep(0.5)
+            node.set_led_off()
+            sleep(1)
+    except KeyboardInterrupt:
+        print("Caught keyboard interrupt - stopping")
+
+    node.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_GPIO_Operations.py
+++ b/tests/test_GPIO_Operations.py
@@ -52,15 +52,5 @@ def test_parse_gpio_pin_state_str_invalid():
     with pytest.raises(ParsingError):
         node.parse_gpio_pin_state_str("invalid string")
 
-def test_exception_raised_on_invalid_gpio_pin_number_high():
-    node = UartDwm1001(mock_serial)
-    with pytest.raises(ReservedGPIOPinError):
-        node.set_gpio_pin_high(1)
-
-def test_exception_raised_on_invalid_gpio_pin_number_low():
-    node = UartDwm1001(mock_serial)
-    with pytest.raises(ReservedGPIOPinError):
-        node.set_gpio_pin_low(3)
-
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_GPIO_Operations.py
+++ b/tests/test_GPIO_Operations.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import pytest
+from unittest import mock
+from serial import Serial
+
+# Add module directory to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Import modules under test
+from dwm1001 import ParsingError, UartDwm1001, ReservedGPIOPinError
+
+valid_gpio_pins = [2, 8, 9, 10, 12, 13, 14, 15, 23, 27]
+invalid_gpio_pins = [0, 1, 3, 4, 5, 6, 7, 11, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 28, 29, 30, 31]
+example_gpio_get_str_2_LOW = "gpio2: 0"
+example_gpio_get_str_2_HIGH = "gpio2: 1"
+example_gpio_get_str_14_LOW = "gpio14: 0"
+example_gpio_get_str_14_HIGH = "gpio14: 1"
+
+mock_serial = mock.Mock(Serial)
+mock_serial.isOpen = lambda: True
+
+# ************************* Begin Tests ************************* #
+def test_valid_gpio_pin_numbers():
+    node = UartDwm1001(mock_serial)
+    for pin in valid_gpio_pins:
+        assert node.is_valid_gpio_pin(pin) == True
+
+def test_invalid_gpio_pin_numbers():
+    node = UartDwm1001(mock_serial)
+    for pin in invalid_gpio_pins:
+        assert node.is_valid_gpio_pin(pin) == False
+
+def test_parse_gpio_pin_state_str_2_LOW():
+    node = UartDwm1001(mock_serial)
+    assert node.parse_gpio_pin_state_str(example_gpio_get_str_2_LOW) == False
+
+def test_parse_gpio_pin_state_str_2_HIGH():
+    node = UartDwm1001(mock_serial)
+    assert node.parse_gpio_pin_state_str(example_gpio_get_str_2_HIGH) == True
+
+def test_parse_gpio_pin_state_str_14_LOW():
+    node = UartDwm1001(mock_serial)
+    assert node.parse_gpio_pin_state_str(example_gpio_get_str_14_LOW) == False
+
+def test_parse_gpio_pin_state_str_14_HIGH():
+    node = UartDwm1001(mock_serial)
+    assert node.parse_gpio_pin_state_str(example_gpio_get_str_14_HIGH) == True
+
+def test_parse_gpio_pin_state_str_invalid():
+    node = UartDwm1001(mock_serial)
+    with pytest.raises(ParsingError):
+        node.parse_gpio_pin_state_str("invalid string")
+
+def test_exception_raised_on_invalid_gpio_pin_number_high():
+    node = UartDwm1001(mock_serial)
+    with pytest.raises(ReservedGPIOPinError):
+        node.set_gpio_pin_high(1)
+
+def test_exception_raised_on_invalid_gpio_pin_number_low():
+    node = UartDwm1001(mock_serial)
+    with pytest.raises(ReservedGPIOPinError):
+        node.set_gpio_pin_low(3)
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Added methods to control the set of GPIO pins on the dwm1001 chip that the user has control of. This is a subset of pins, the most notable being GPIO_14 that runs the D12 LED on the dev board, and the three pins on the J2 header.

Future work:
- Finally figure out how to mock up a serial port so the testing can be done down to the serial port level.