### PR TITLE
Feature: Listing Network Anchors by Tag Node

### DIFF
--- a/.github/workflows/dwm1001test.yml
+++ b/.github/workflows/dwm1001test.yml
@@ -7,10 +7,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - name: Set up Python 3.8
+            - name: Set up Python 3.10
               uses: actions/setup-python@v3
               with:
-                  python-version: 3.8
+                  python-version: 3.10
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
@@ -22,10 +22,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - name: Set up Python 3.8
+            - name: Set up Python 3.10
               uses: actions/setup-python@v3
               with:
-                  python-version: 3.8
+                  python-version: 3.10
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip

--- a/.github/workflows/dwm1001test.yml
+++ b/.github/workflows/dwm1001test.yml
@@ -7,10 +7,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - name: Set up Python 3.10
+            - name: Set up Python 3.8
               uses: actions/setup-python@v3
               with:
-                  python-version: 3.10
+                  python-version: 3.8
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
@@ -22,10 +22,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - name: Set up Python 3.10
+            - name: Set up Python 3.8
               uses: actions/setup-python@v3
               with:
-                  python-version: 3.10
+                  python-version: 3.8
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip

--- a/dwm1001.py
+++ b/dwm1001.py
@@ -131,7 +131,7 @@ class TagPosition:
         """
         return (self.x_m, self.y_m, self.z_m)
     
-    def get_as_list(self) -> list[float]:
+    def get_as_list(self) -> list:
         """! Gets the position as a list of floats.
         @return list[float]: The position as a list of floats.
 

--- a/dwm1001.py
+++ b/dwm1001.py
@@ -131,7 +131,7 @@ class TagPosition:
         """
         return (self.x_m, self.y_m, self.z_m)
     
-    def get_as_list(self) -> list[float, float, float]:
+    def get_as_list(self) -> list:
         """! Gets the position as a list of floats.
         @return list[float]: The position as a list of floats.
 

--- a/dwm1001.py
+++ b/dwm1001.py
@@ -131,7 +131,7 @@ class TagPosition:
         """
         return (self.x_m, self.y_m, self.z_m)
     
-    def get_as_list(self) -> list:
+    def get_as_list(self) -> list[float, float, float]:
         """! Gets the position as a list of floats.
         @return list[float]: The position as a list of floats.
 
@@ -510,14 +510,14 @@ class UartDwm1001:
         """
         return pin in [2, 8, 9, 10, 12, 13, 14, 15, 23, 27]
 
-    def get_list_of_anchors(self) -> list[AnchorNodeData]:
+    def get_list_of_anchors(self) -> list:
         """! Gets a list of anchors currently seen by the DWM1001.
         @return list[AnchorNodeData]: A list of AnchorNodeData instances.
         """
         anchor_list_str = self.get_command_output(ShellCommand.GET_ANCHOR_LIST.value)
         return self._parse_anchor_list_str(anchor_list_str)
     
-    def _parse_anchor_list_str(self, anchor_list_str: str) -> list[AnchorNodeData]:
+    def _parse_anchor_list_str(self, anchor_list_str: str) -> list:
         """! Parses the output of the "List Anchors" command to get a list of anchors.
         @param anchor_list_str (str): The output of the 'list anchors' command.
         @return list[AnchorNodeData]: A list of AnchorNodeData instances.

--- a/examples/show_anchors_seen.py
+++ b/examples/show_anchors_seen.py
@@ -30,7 +30,7 @@ def main() -> NoReturn:
 
     try:
         while True:
-            anchors_seen_count = node.get_anchor_seen_count()
+            anchors_seen_count = node.get_anchors_seen_count()
             print(f"Anchors seen count: {anchors_seen_count}")
             anchors_seen_list = node.get_list_of_anchors()
             print(f"Anchors seen list: {anchors_seen_list}")

--- a/examples/show_anchors_seen.py
+++ b/examples/show_anchors_seen.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Standard library imports
+from pathlib import Path
+import sys
+from typing import NoReturn
+from time import sleep
+import logging
+
+# Third party imports
+from serial import Serial
+
+# Allows us to find dwm1001 library without installing it
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import dwm1001
+
+SERIAL_PORT_PATH = "/dev/ttyACM0"
+
+
+def main() -> NoReturn:
+    logging.basicConfig(level=logging.INFO)  # Set to DEBUG for more info
+    # logging.basicConfig(level=logging.DEBUG)  # Set to DEBUG for more info
+
+    serial_handle = Serial(SERIAL_PORT_PATH, baudrate=115200, timeout=5)
+
+    node = dwm1001.UartDwm1001(serial_handle)
+    node.connect()
+
+    print("Connected, Showing Current seen anchors list, press Ctrl+C to stop")
+
+    try:
+        while True:
+            anchors_seen_count = node.get_anchor_seen_count()
+            print(f"Anchors seen count: {anchors_seen_count}")
+            anchors_seen_list = node.get_list_of_anchors()
+            print(f"Anchors seen list: {anchors_seen_list}")
+            sleep(5)
+            print("-" * 79)
+    except KeyboardInterrupt:
+        print("Caught keyboard interrupt - stopping")
+
+    node.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_AnchorNodeData.py
+++ b/tests/test_AnchorNodeData.py
@@ -52,7 +52,7 @@ def test_anchor_node_constructor_2():
 
 def test_list_anchors_command():
     dwm1001node = UartDwm1001(mock_serial)
-    anchor_list = dwm1001node.parse_anchor_list_str(list_anchors_str)
+    anchor_list = dwm1001node._parse_anchor_list_str(list_anchors_str)
 
     assert len(anchor_list) == 4
     assert anchor_list[0].id == "000000000000C920"
@@ -64,28 +64,28 @@ def test_list_anchors_command():
 
 def test_list_anchors_command_0():
     dwm1001node = UartDwm1001(mock_serial)
-    anchor_list = dwm1001node.parse_anchor_list_str(list_anchors_str_0)
+    anchor_list = dwm1001node._parse_anchor_list_str(list_anchors_str_0)
 
     assert len(anchor_list) == 0
 
 def test_get_seen_anchor_count_0():
     expected_anchor_count = 0
     dwm1001node = UartDwm1001(mock_serial)
-    anchor_count = dwm1001node.parse_anchor_seen_count_str(list_anchors_str_0)
+    anchor_count = dwm1001node._parse_anchors_seen_count_str(list_anchors_str_0)
 
     assert anchor_count == expected_anchor_count
 
 def test_get_seen_anchor_count_4():
     expected_anchor_count = 4
     dwm1001node = UartDwm1001(mock_serial)
-    anchor_count = dwm1001node.parse_anchor_seen_count_str(list_anchors_str_4)
+    anchor_count = dwm1001node._parse_anchors_seen_count_str(list_anchors_str_4)
 
     assert anchor_count == expected_anchor_count
 
 def test_get_seen_anchor_count_13():
     expected_anchor_count = 13
     dwm1001node = UartDwm1001(mock_serial)
-    anchor_count = dwm1001node.parse_anchor_seen_count_str(list_anchors_str_13)
+    anchor_count = dwm1001node._parse_anchors_seen_count_str(list_anchors_str_13)
 
     assert anchor_count == expected_anchor_count
 

--- a/tests/test_AnchorNodeData.py
+++ b/tests/test_AnchorNodeData.py
@@ -89,4 +89,13 @@ def test_get_seen_anchor_count_13():
 
     assert anchor_count == expected_anchor_count
 
+def test_construct_invalid_string_1():
+    invalid_string = "Invalid String Input"
+    with pytest.raises(ParsingError):
+        AnchorNodeData.from_string(invalid_string)
 
+def test_invalid_anchor_count_parse():
+    invalid_string = "Invalid String Input"
+    dwm1001node = UartDwm1001(mock_serial)
+    with pytest.raises(ParsingError):
+        dwm1001node._parse_anchors_seen_count_str(invalid_string)

--- a/tests/test_AnchorNodeData.py
+++ b/tests/test_AnchorNodeData.py
@@ -1,0 +1,92 @@
+import os
+import sys
+import pytest
+from unittest import mock
+from serial import Serial
+
+# Add module directory to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Import modules under test
+from dwm1001 import ParsingError, UartDwm1001, AnchorNodeData, TagPosition
+
+mock_serial = mock.Mock(Serial)
+mock_serial.isOpen = lambda: True
+
+anchor_data_0 = "[003976.620 INF]   0) id=000000000000C920 seat=0 idl=0 seens=40 lqi=0 fl=5001 map=00000000 pos=0.38:0.84:2.15"
+anchor_data_1 = "[003976.630 INF]   1) id=0000000000008389 seat=3 idl=0 seens=116 lqi=0 fl=5001 map=00000002 pos=114.96:2.50:-1.78"
+anchor_data_2 = "[003976.640 INF]   2) id=0000000000000E0B seat=14 idl=0 seens=2103 lqi=0 fl=5001 map=00000002 pos=-0.0:-8000.63:-1.13"
+
+list_anchors_str = """[005899.170 INF] AN: cnt=4 seq=x09
+[005899.170 INF]   0) id=000000000000C920 seat=0 idl=0 seens=75 lqi=0 fl=5001 map=00000000 pos=0.38:0.84:2.15
+[005899.180 INF]   1) id=0000000000008389 seat=3 idl=0 seens=42 lqi=0 fl=5001 map=00000001 pos=4.96:2.50:1.78
+[005899.190 INF]   2) id=0000000000000E0B seat=4 idl=0 seens=32 lqi=0 fl=5001 map=00000001 pos=0.64:8.63:1.13
+[005899.200 INF]   3) id=0000000000004505 seat=1 idl=0 seens=196 lqi=0 fl=5001 map=00000001 pos=5.14:9.03:1.35
+[005899.210 INF]"""
+
+list_anchors_str_0 = """[005899.170 INF] AN: cnt=0 seq=x09"""
+list_anchors_str_4 = """[005899.170 INF] AN: cnt=4 seq=xA9"""
+list_anchors_str_13 = """[005899.170 INF] AN: cnt=13 seq=x06"""
+
+# ************************* Begin Tests ************************* #
+def test_anchor_node_constructor_0():
+    anchor_node = AnchorNodeData.from_string(anchor_data_0)
+    assert anchor_node.id == "000000000000C920"
+    assert anchor_node.seat == 0
+    assert anchor_node.seens == 40
+    assert anchor_node.position == TagPosition(0.38, 0.84, 2.15, 0)
+
+def test_anchor_node_constructor_1():
+    anchor_node = AnchorNodeData.from_string(anchor_data_1)
+    assert anchor_node.id == "0000000000008389"
+    assert anchor_node.seat == 3
+    assert anchor_node.seens == 116
+    assert anchor_node.position == TagPosition(114.96,2.50,-1.78,0)
+
+def test_anchor_node_constructor_2():
+    anchor_node = AnchorNodeData.from_string(anchor_data_2)
+    assert anchor_node.id == "0000000000000E0B"
+    assert anchor_node.seat == 14
+    assert anchor_node.seens == 2103
+    assert anchor_node.position == TagPosition(-0.0,-8000.63,-1.13,0)
+
+def test_list_anchors_command():
+    dwm1001node = UartDwm1001(mock_serial)
+    anchor_list = dwm1001node.parse_anchor_list_str(list_anchors_str)
+
+    assert len(anchor_list) == 4
+    assert anchor_list[0].id == "000000000000C920"
+    assert anchor_list[0].seat == 0
+    assert anchor_list[1].id == "0000000000008389"
+    assert anchor_list[1].seens == 42
+    assert anchor_list[2].id == "0000000000000E0B"
+    assert anchor_list[3].id == "0000000000004505"
+
+def test_list_anchors_command_0():
+    dwm1001node = UartDwm1001(mock_serial)
+    anchor_list = dwm1001node.parse_anchor_list_str(list_anchors_str_0)
+
+    assert len(anchor_list) == 0
+
+def test_get_seen_anchor_count_0():
+    expected_anchor_count = 0
+    dwm1001node = UartDwm1001(mock_serial)
+    anchor_count = dwm1001node.parse_anchor_seen_count_str(list_anchors_str_0)
+
+    assert anchor_count == expected_anchor_count
+
+def test_get_seen_anchor_count_4():
+    expected_anchor_count = 4
+    dwm1001node = UartDwm1001(mock_serial)
+    anchor_count = dwm1001node.parse_anchor_seen_count_str(list_anchors_str_4)
+
+    assert anchor_count == expected_anchor_count
+
+def test_get_seen_anchor_count_13():
+    expected_anchor_count = 13
+    dwm1001node = UartDwm1001(mock_serial)
+    anchor_count = dwm1001node.parse_anchor_seen_count_str(list_anchors_str_13)
+
+    assert anchor_count == expected_anchor_count
+
+

--- a/tests/test_GPIO_Operations.py
+++ b/tests/test_GPIO_Operations.py
@@ -33,24 +33,24 @@ def test_invalid_gpio_pin_numbers():
 
 def test_parse_gpio_pin_state_str_2_LOW():
     node = UartDwm1001(mock_serial)
-    assert node.parse_gpio_pin_state_str(example_gpio_get_str_2_LOW) == False
+    assert node._parse_gpio_pin_state_str(example_gpio_get_str_2_LOW) == False
 
 def test_parse_gpio_pin_state_str_2_HIGH():
     node = UartDwm1001(mock_serial)
-    assert node.parse_gpio_pin_state_str(example_gpio_get_str_2_HIGH) == True
+    assert node._parse_gpio_pin_state_str(example_gpio_get_str_2_HIGH) == True
 
 def test_parse_gpio_pin_state_str_14_LOW():
     node = UartDwm1001(mock_serial)
-    assert node.parse_gpio_pin_state_str(example_gpio_get_str_14_LOW) == False
+    assert node._parse_gpio_pin_state_str(example_gpio_get_str_14_LOW) == False
 
 def test_parse_gpio_pin_state_str_14_HIGH():
     node = UartDwm1001(mock_serial)
-    assert node.parse_gpio_pin_state_str(example_gpio_get_str_14_HIGH) == True
+    assert node._parse_gpio_pin_state_str(example_gpio_get_str_14_HIGH) == True
 
 def test_parse_gpio_pin_state_str_invalid():
     node = UartDwm1001(mock_serial)
     with pytest.raises(ParsingError):
-        node.parse_gpio_pin_state_str("invalid string")
+        node._parse_gpio_pin_state_str("invalid string")
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_TagPosition.py
+++ b/tests/test_TagPosition.py
@@ -65,6 +65,17 @@ def test_almost_equality_not_equal():
 
     assert not position1.is_almost_equal(position2)
 
+def test_get_as_tuple():
+    position = TagPosition(1.23, 4.56, 7.89, 42)
+    position_tuple = position.get_as_tuple()
+
+    assert position_tuple == (1.23, 4.56, 7.89)
+
+def test_get_as_list():
+    position = TagPosition(1.23, 4.56, 7.89, 42)
+    position_list = position.get_as_list()
+
+    assert position_list == [1.23, 4.56, 7.89]
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_UartDwm1001.py
+++ b/tests/test_UartDwm1001.py
@@ -61,7 +61,7 @@ def test_dwm1001_get_uptime_ms():
 
     dwm1001 = UartDwm1001(mock_serial)
 
-    actual_uptime_ms = dwm1001.parse_uptime_str(uptime_return_str)
+    actual_uptime_ms = dwm1001._parse_uptime_str(uptime_return_str)
     assert actual_uptime_ms == expected_uptime_ms
 
 
@@ -73,7 +73,7 @@ def test_dwm1001_get_uptime_ms_small():
 
     dwm1001 = UartDwm1001(mock_serial)
 
-    actual_uptime_ms = dwm1001.parse_uptime_str(uptime_return_str)
+    actual_uptime_ms = dwm1001._parse_uptime_str(uptime_return_str)
     assert actual_uptime_ms == expected_uptime_ms
 
 
@@ -83,7 +83,7 @@ def test_parse_get_ble_address():
 
     dwm1001 = UartDwm1001(mock_serial)
 
-    actual_ble_address = dwm1001.parse_ble_address(ble_address_return_str)
+    actual_ble_address = dwm1001._parse_ble_address(ble_address_return_str)
     assert actual_ble_address == expected_ble_address
 
 
@@ -93,7 +93,7 @@ def test_parse_network_id():
 
     dwm1001 = UartDwm1001(mock_serial)
 
-    actual_network_id = dwm1001.parse_network_id(network_id_return_str)
+    actual_network_id = dwm1001._parse_network_id(network_id_return_str)
     assert actual_network_id == expected_network_id
 
 
@@ -103,7 +103,7 @@ def test_parse_accelerometer_str():
 
     dwm1001 = UartDwm1001(mock_serial)
 
-    actual_accelerometer_data = dwm1001.parse_accelerometer_str(
+    actual_accelerometer_data = dwm1001._parse_accelerometer_str(
         accelerometer_return_str
     )
     assert actual_accelerometer_data == expected_accelerometer_data
@@ -115,7 +115,7 @@ def test_parse_accelerometer_str_highvals():
 
     dwm1001 = UartDwm1001(mock_serial)
 
-    actual_accelerometer_data = dwm1001.parse_accelerometer_str(
+    actual_accelerometer_data = dwm1001._parse_accelerometer_str(
         accelerometer_return_str
     )
     assert actual_accelerometer_data == expected_accelerometer_data
@@ -127,7 +127,7 @@ def test_parse_node_mode_tag_active():
 
     dwm1001 = UartDwm1001(mock_serial)
 
-    actual_node_mode = dwm1001.parse_node_mode_str(node_mode_return_str)
+    actual_node_mode = dwm1001._parse_node_mode_str(node_mode_return_str)
     assert actual_node_mode == expected_node_mode
 
 
@@ -137,7 +137,7 @@ def test_parse_node_mode_tag_passive():
 
     dwm1001 = UartDwm1001(mock_serial)
 
-    actual_node_mode = dwm1001.parse_node_mode_str(node_mode_return_str)
+    actual_node_mode = dwm1001._parse_node_mode_str(node_mode_return_str)
     assert actual_node_mode == expected_node_mode
 
 
@@ -147,7 +147,7 @@ def test_parse_node_mode_tag_off():
 
     dwm1001 = UartDwm1001(mock_serial)
 
-    actual_node_mode = dwm1001.parse_node_mode_str(node_mode_return_str)
+    actual_node_mode = dwm1001._parse_node_mode_str(node_mode_return_str)
     assert actual_node_mode == expected_node_mode
 
 


### PR DESCRIPTION
This PR adds the API call to list network anchors, and to get the positions reported by the anchors.

* Additional changes to make parsing methods protected (single _) for proper API design and documentation.

Known bug:

* I found that in anchor mode, the 'la' call reports the strings in a different format so this parsing doesn't fully work, so I'll get that fixed soon.